### PR TITLE
Explicitely set audio channels to stereo

### DIFF
--- a/src/main/java/eu/siacs/conversations/voicerecorder/ui/RecordingActivity.java
+++ b/src/main/java/eu/siacs/conversations/voicerecorder/ui/RecordingActivity.java
@@ -80,6 +80,7 @@ public class RecordingActivity extends Activity implements View.OnClickListener 
 
 	private boolean startRecording() {
 		mRecorder = new MediaRecorder();
+		mRecorder.setAudioChannels(2);
 		mRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
 		mRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {


### PR DESCRIPTION
Setting it to mono (1) didn't change anything, but setting to stereo worked. Fixes the resulting file which now can be played with Qt/Chromium, and shouldn't affect the filesize, as both channels will in most cases be identical and compress well.

Closes #18